### PR TITLE
Maintenance PR

### DIFF
--- a/.github/workflows/appstore-build-publish.yml
+++ b/.github/workflows/appstore-build-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only allowed to be run on nextcloud-releases repositories
-    if: ${{ github.repository_owner == 'cloud-py-api' }}
+    if: ${{ github.repository_owner == 'nextcloud' }}
 
     steps:
       - name: Check actor permission

--- a/.github/workflows/publish-docker-cpu.yml
+++ b/.github/workflows/publish-docker-cpu.yml
@@ -1,4 +1,4 @@
-name: Publish CPU
+name: Publish CPU Image
 
 on:
   workflow_dispatch:
@@ -6,8 +6,8 @@ on:
 jobs:
   push_to_registry:
     name: Build image
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'cloud-py-api' }}
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'nextcloud' }}
     permissions:
       packages: write
       contents: read
@@ -87,7 +87,7 @@ jobs:
         with:
           push: true
           context: ./${{ env.APP_NAME }}
-          platforms: linux/amd64,linux/arm64/v8
-          tags: ghcr.io/cloud-py-api/talk_bot_ai:${{ env.VERSION }}
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/nextcloud/${{ env.APP_NAME }}:${{ env.VERSION }}
           build-args: |
             BUILD_TYPE=cpu

--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -16,8 +16,6 @@
 /babel.config.js
 /build
 /APPS.md
-/AUTHORS.md
-/CHANGELOG.md
 /HOW_TO_INSTALL.md
 /README.md
 /composer.*

--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -16,7 +16,6 @@
 /babel.config.js
 /build
 /APPS.md
-/HOW_TO_INSTALL.md
 /README.md
 /composer.*
 /node_modules

--- a/HOW_TO_INSTALL.md
+++ b/HOW_TO_INSTALL.md
@@ -1,8 +1,0 @@
-How To Install
-==============
-
-1. Install **AppAPI** from the [Appstore](https://apps.nextcloud.com/apps/app_api).
-2. Create a deployment daemon following the [instructions](https://cloud-py-api.github.io/app_api/CreationOfDeployDaemon.html) provided by AppAPI. _(If you are using AIO, it will be created automatically)_
-3. Navigate to the `External Apps` menu from your Nextcloud instance, find this app, and click `Deploy and Enable`.
-4. In Nextcloud Talk, choose a conversation and enable the bot in `Conversation settings`.
-5. Now you can invoke the bot by typing `@assistant` followed by a prompt in the conversation (e.g. `@assistant I have a question for you.`).

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ help:
 .PHONY: build-push
 build-push:
 	docker login ghcr.io
-	docker buildx create --name $(APP_ID) --driver docker-container --platform linux/amd64,linux/arm64/v8 --use || true
-	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION) --tag ghcr.io/nextcloud/$(APP_ID):latest .
+	docker buildx create --name $(APP_ID) --driver docker-container --platform linux/amd64,linux/arm64 --use || true
+	docker buildx build --push --platform linux/arm64,linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION) --tag ghcr.io/nextcloud/$(APP_ID):latest .
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -2,26 +2,29 @@
 
 APP_ID := talk_bot_ai
 APP_NAME := AssistantTalkBot
-APP_VERSION := 3.0.0
+APP_VERSION := $$(xmlstarlet sel -t -v "//version" appinfo/info.xml)
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":10034}"
 
 .PHONY: help
 help:
-	@echo "Welcome to the Nextcloud Assistant talk bot. Please use \`make <target>\` where <target> is one of:"
+	@echo "  Welcome to Nextcloud $(APP_NAME) $(APP_VERSION)!"
 	@echo " "
-	@echo "  Next commands are only for dev environment with nextcloud-docker-dev!"
-	@echo "  They should run from the host you are developing on (with activated venv) and not in the container with Nextcloud!"
-	@echo "  "
-	@echo "  build-push        build image and upload to ghcr.io"
-	@echo "  "
-	@echo "  run               install $(APP_NAME) for Nextcloud Latest"
-	@echo "  run30             install $(APP_NAME) for Nextcloud 30"
-	@echo "  "
-	@echo "  For development of this app use PyCharm run configurations. Development is always set for last Nextcloud."
-	@echo "  First run '$(APP_NAME)' and then 'make register', after that you can use/debug/develop it and easy test."
-	@echo "  "
-	@echo "  register          perform registration of running '$(APP_NAME)' into the 'manual_install' deploy daemon."
-	@echo "  register30        perform registration of running '$(APP_NAME)' into the 'manual_install' deploy daemon."
+	@echo "  Please use \`make <target>\` where <target> is one of"
+	@echo " "
+	@echo "  build-push        builds CPU images and uploads them to ghcr.io"
+	@echo " "
+	@echo "  > Next commands are only for the dev environment with nextcloud-docker-dev!"
+	@echo "  > They must be run from the host you are developing on, not in a Nextcloud container!"
+	@echo " "
+	@echo "  run               installs $(APP_NAME) for Nextcloud Latest"
+	@echo "  run30             installs $(APP_NAME) for Nextcloud 30"
+	@echo " "
+	@echo "  > Commands for manual registration of ExApp($(APP_NAME) should be running!):"
+	@echo " "
+	@echo "  register          performs registration of running $(APP_NAME) into the 'manual_install' deploy daemon."
+	@echo "  register30        performs registration of running $(APP_NAME) into the 'manual_install' deploy daemon."
+	@echo " "
+
 
 .PHONY: build-push
 build-push:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "  run               installs $(APP_NAME) for Nextcloud Latest"
 	@echo "  run30             installs $(APP_NAME) for Nextcloud 30"
 	@echo " "
-	@echo "  > Commands for manual registration of ExApp($(APP_NAME) should be running!):"
+	@echo "  > Commands for manual registration of ExApp ($(APP_NAME) should be running!):"
 	@echo " "
 	@echo "  register          performs registration of running $(APP_NAME) into the 'manual_install' deploy daemon."
 	@echo "  register30        performs registration of running $(APP_NAME) into the 'manual_install' deploy daemon."

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 APP_ID := talk_bot_ai
 APP_NAME := AssistantTalkBot
 APP_VERSION := 3.0.0
-JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"Assistant Talk Bot\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":10034,\"scopes\":[\"ALL\"]}"
+JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":10034}"
 
 .PHONY: help
 help:
@@ -27,26 +27,26 @@ help:
 build-push:
 	docker login ghcr.io
 	docker buildx create --name $(APP_ID) --driver docker-container --platform linux/amd64,linux/arm64/v8 --use || true
-	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/cloud-py-api/$(APP_ID):$(APP_VERSION) --tag ghcr.io/cloud-py-api/$(APP_ID):latest .
+	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION) --tag ghcr.io/nextcloud/$(APP_ID):latest .
 
 .PHONY: run
 run:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister $(APP_ID) --silent --force || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --force-scopes \
-		--info-xml https://raw.githubusercontent.com/cloud-py-api/$(APP_ID)/main/appinfo/info.xml
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) \
+		--info-xml https://raw.githubusercontent.com/nextcloud/$(APP_ID)/main/appinfo/info.xml
 
 .PHONY: run30
 run30:
 	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:unregister $(APP_ID) --silent --force || true
-	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:register $(APP_ID) --force-scopes \
-		--info-xml https://raw.githubusercontent.com/cloud-py-api/$(APP_ID)/main/appinfo/info.xml
+	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:register $(APP_ID) \
+		--info-xml https://raw.githubusercontent.com/nextcloud/$(APP_ID)/main/appinfo/info.xml
 
 .PHONY: register
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister $(APP_ID) --silent --force || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) manual_install --json-info $(JSON_INFO) --force-scopes --wait-finish
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) manual_install --json-info $(JSON_INFO) --wait-finish
 
 .PHONY: register30
 register30:
 	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:unregister $(APP_ID) --silent --force || true
-	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:register $(APP_ID) manual_install --json-info $(JSON_INFO) --force-scopes --wait-finish
+	docker exec master-stable30-1 sudo -u www-data php occ app_api:app:register $(APP_ID) manual_install --json-info $(JSON_INFO) --wait-finish

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Nextcloud Assistant Talk Bot
 
-**A talk bot using [`AppAPI`](https://github.com/cloud-py-api/app_api), Task Processing API, and Talk Bot API.**
+**A talk bot using [`AppAPI`](https://github.com/nextcloud/app_api), Task Processing API, and Talk Bot API.**
 
 The bot is capable of answering questions in chat depending on the model set by Nextcloud Assistant.
 
-Refer to [How to install](https://github.com/cloud-py-api/talk_bot_ai/blob/main/HOW_TO_INSTALL.md) to install the application.
+Refer to [How to install](https://github.com/nextcloud/talk_bot_ai/blob/main/HOW_TO_INSTALL.md) to install the application.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ The bot answers questions in chat based on the model set by Nextcloud Assistant.
 ## How to install:
 
 1. Set up a deployment daemon by following the [AppAPI instructions](https://nextcloud.github.io/app_api/CreationOfDeployDaemon.html). _(Automatically created with AIO)_
-2. Go to the `Apps` menu in Nextcloud, find this app, and click `Deploy and Enable`.
+2. Go to the `Apps` menu in Nextcloud, find this app (`Assistant Talk Bot`) in the `Tools` category, and click `Deploy and Enable`.
 3. In Nextcloud Talk, open a conversation and activate the bot in `Conversation settings`.
 4. Invoke the bot by typing `@assistant` followed by your question (e.g., `@assistant I have a question for you.`).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The bot answers questions in chat based on the model set by Nextcloud Assistant.
 
-## Hot to install:
+## How to install:
 
 1. Set up a deployment daemon by following the [AppAPI instructions](https://nextcloud.github.io/app_api/CreationOfDeployDaemon.html). _(Automatically created with AIO)_
 2. Go to the `Apps` menu in Nextcloud, find this app, and click `Deploy and Enable`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 **A talk bot using [`AppAPI`](https://github.com/nextcloud/app_api), Task Processing API, and Talk Bot API.**
 
-The bot is capable of answering questions in chat depending on the model set by Nextcloud Assistant.
+> **Note:**  
+> The `AppAPI` application needs to be enabled to install and use this bot.
 
-Refer to [How to install](https://github.com/nextcloud/talk_bot_ai/blob/main/HOW_TO_INSTALL.md) to install the application.
+The bot answers questions in chat based on the model set by Nextcloud Assistant.
+
+## Hot to install:
+
+1. Set up a deployment daemon by following the [AppAPI instructions](https://nextcloud.github.io/app_api/CreationOfDeployDaemon.html). _(Automatically created with AIO)_
+2. Go to the `Apps` menu in Nextcloud, find this app, and click `Deploy and Enable`.
+3. In Nextcloud Talk, open a conversation and activate the bot in `Conversation settings`.
+4. Invoke the bot by typing `@assistant` followed by your question (e.g., `@assistant I have a question for you.`).

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 **A talk bot using [`AppAPI`](https://github.com/nextcloud/app_api), Task Processing API, and Talk Bot API.**
 
 The bot is capable of answering questions in chat depending on the model set by Nextcloud Assistant.
-.
+
 **The [`AppAPI`](https://github.com/nextcloud/app_api) application needs to be enabled to install and use this bot.**
 	]]></description>
 	<version>3.0.0</version>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,11 +5,11 @@
 	<summary>Nextcloud Assistant Talk Bot</summary>
 	<description>
 	<![CDATA[
-**A talk bot using [`AppAPI`](https://github.com/cloud-py-api/app_api), Task Processing API, and Talk Bot API.**
+**A talk bot using [`AppAPI`](https://github.com/nextcloud/app_api), Task Processing API, and Talk Bot API.**
 
 The bot is capable of answering questions in chat depending on the model set by Nextcloud Assistant.
 
-Refer to [How to install](https://github.com/cloud-py-api/talk_bot_ai/blob/main/HOW_TO_INSTALL.md) to install the application.
+Refer to [How to install](https://github.com/nextcloud/talk_bot_ai/blob/main/HOW_TO_INSTALL.md) to install the application.
 	]]></description>
 	<version>3.0.0</version>
 	<licence>MIT</licence>
@@ -18,22 +18,18 @@ Refer to [How to install](https://github.com/cloud-py-api/talk_bot_ai/blob/main/
 	<author mail="contact@edward.ly" homepage="https://github.com/edward-ly">Edward Ly</author>
 	<namespace>AssistantTalkBot</namespace>
 	<category>tools</category>
-	<screenshot>https://raw.githubusercontent.com/cloud-py-api/talk_bot_ai/main/screenshots/talk_bot_ai.png</screenshot>
-	<website>https://github.com/cloud-py-api/talk_bot_ai</website>
-	<bugs>https://github.com/cloud-py-api/talk_bot_ai/issues</bugs>
-	<repository type="git">https://github.com/cloud-py-api/talk_bot_ai.git</repository>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/talk_bot_ai/main/screenshots/talk_bot_ai.png</screenshot>
+	<website>https://github.com/nextcloud/talk_bot_ai</website>
+	<bugs>https://github.com/nextcloud/talk_bot_ai/issues</bugs>
+	<repository type="git">https://github.com/nextcloud/talk_bot_ai.git</repository>
 	<dependencies>
 		<nextcloud min-version="30" max-version="31"/>
 	</dependencies>
 	<external-app>
 		<docker-install>
 			<registry>ghcr.io</registry>
-			<image>cloud-py-api/talk_bot_ai</image>
+			<image>nextcloud/talk_bot_ai</image>
 			<image-tag>3.0.0</image-tag>
 		</docker-install>
-		<scopes>
-			<value>ALL</value>
-		</scopes>
-		<system>false</system>
 	</external-app>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,8 +8,8 @@
 **A talk bot using [`AppAPI`](https://github.com/nextcloud/app_api), Task Processing API, and Talk Bot API.**
 
 The bot is capable of answering questions in chat depending on the model set by Nextcloud Assistant.
-
-Refer to [How to install](https://github.com/nextcloud/talk_bot_ai/blob/main/HOW_TO_INSTALL.md) to install the application.
+.
+**The [`AppAPI`](https://github.com/nextcloud/app_api) application needs to be enabled to install and use this bot.**
 	]]></description>
 	<version>3.0.0</version>
 	<licence>MIT</licence>


### PR DESCRIPTION
Changes suggested in this PR:

- removed deprecated api-scopes
- changed `cloud-py-api` references to `nextcloud`

What else is missing:

- probably we don't need `HOW_TO_INSTALL.md` anymore, since `30.0.1` NC AppAPI is already enabled?
- some `Readme.md` and description in `info.xml` adjustments maybe?
- make a PR to `spreed` repository to fix URLs here: https://github.com/nextcloud/spreed/blob/0a0ced140c4fb2ce2b9ca6b273b7120d9c6e8b3d/docs/bot-list.md?plain=1#L64

This can come in this PR or in another one.