### PR TITLE
fix: match newline characters and trim whitespace in prompt

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -33,7 +33,7 @@ AI_BOT = talk_bot.TalkBot("/" + BOT_URL, "Assistant Talk Bot", "Usage: `@assista
 
 def ai_talk_bot_process_request(message: TalkBotMessage, nc: NextcloudApp):
     message_text = message.object_content["message"]
-    prompt = re.search(r"@assistant\s(.*)", message_text, re.IGNORECASE)
+    prompt = re.search(r"@assistant\s+(.*)\s*", message_text, re.IGNORECASE | re.DOTALL)
 
     if prompt is None:
         return


### PR DESCRIPTION
Fixes #16.

Fixes a bug where only the first line of the prompt was matched, so multi-line prompts are now recognized and handled properly.

Also fixes a bug where the first line being empty (where the prompt starts on a separate line from `@assistant`) results in an empty prompt.