### PR TITLE
fix(HaRP): install "procps" that is used in the healthcheck action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.12-slim-bookworm
 
 RUN \
   apt-get update && \
-  apt-get install -y curl && \
+  apt-get install -y curl procps && \
   apt-get autoclean
 
 # Download and install FRP client into /usr/local/bin.


### PR DESCRIPTION
Found during testing. Without `healthckeck`, deployment fails due to:

```
pgrep -x "frpc"
bash: pgrep: command not found
```

If possible, a new version with this fix would be useful before the NC32 release, when we will start recommending `HaRP` as the default deployment method instead of `DSP`.