### PR TITLE
ci(workflows): add `latest` version tag to build images

### DIFF
--- a/.github/workflows/publish-docker-cpu.yml
+++ b/.github/workflows/publish-docker-cpu.yml
@@ -97,6 +97,8 @@ jobs:
           push: true
           context: ./${{ env.APP_NAME }}
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/nextcloud/${{ env.APP_NAME }}:${{ env.VERSION }}
+          tags: |
+            ghcr.io/nextcloud/${{ env.APP_NAME }}:${{ env.VERSION }}
+            ghcr.io/nextcloud/${{ env.APP_NAME }}:latest
           build-args: |
             BUILD_TYPE=cpu

--- a/.github/workflows/publish-docker-cpu.yml
+++ b/.github/workflows/publish-docker-cpu.yml
@@ -6,6 +6,7 @@ name: Publish CPU Image
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   packages: write


### PR DESCRIPTION
Fixes the current situation in the [package page](https://github.com/nextcloud/talk_bot_ai/pkgs/container/talk_bot_ai) where the `latest` Docker image isn't actually pointing to the latest build.

@oleksandr-nc feel free to merge if everything looks good to you